### PR TITLE
only apply to strings (match doesn't work elsewhere)

### DIFF
--- a/lib/localize_input.rb
+++ b/lib/localize_input.rb
@@ -11,11 +11,13 @@ module LocalizeInput
       attr_names.flatten.each do |attr|
         define_method "#{attr}=" do |input|
           begin
-            Rails.logger.debug "Input: #{input.inspect}"
-            separator = I18n.t("separator", :scope => "number.format")
-            delimiter = I18n.t("delimiter", :scope => "number.format")
-            input.gsub!(delimiter, "") if input.match(/\d+#{Regexp.escape(delimiter)}+\d+#{Regexp.escape(separator)}+\d+/) # Remove delimiter
-            input.gsub!(separator, ".") # Replace separator with db compatible character
+            if input.is_a? String
+              Rails.logger.debug "Input: #{input.inspect}"
+              separator = I18n.t("separator", :scope => "number.format")
+              delimiter = I18n.t("delimiter", :scope => "number.format")
+              input.gsub!(delimiter, "") if input.match(/\d+#{Regexp.escape(delimiter)}+\d+#{Regexp.escape(separator)}+\d+/) # Remove delimiter
+              input.gsub!(separator, ".") # Replace separator with db compatible character
+            end
             self[attr] = input
           rescue
             Rails.logger.warn "Can't localize input: #{input}"


### PR DESCRIPTION
main annoyance was a lot of useless log noise, but match does not work on anything but strings.  

